### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ESP32 Build & Quality Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/derdoktor667/DShotRMT/security/code-scanning/3](https://github.com/derdoktor667/DShotRMT/security/code-scanning/3)

To fix the problem, explicitly define the minimal `permissions` block at the root of the workflow. This will ensure all jobs default to the least privileged settings, following the principle of least privilege. Since this workflow does not interact with issues, pull requests, or protected content, and only checks out code and summarizes results, the recommended least privilege permissions are `contents: read`. This will allow actions like `actions/checkout` to work while denying write access. 

Edit the `.github/workflows/ci.yml` file, adding a `permissions:` block after the workflow `name:` to apply to all jobs. No changes to individual jobs or steps are required. No additional imports, method definitions, or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
